### PR TITLE
Add writing collection and page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -240,6 +240,9 @@ collections:
   working_papers:
     output: true
     permalink: /:collection/:path
+  writing:
+    output: true
+    permalink: /:collection/:path/
 
 
 # These settings control how pages and collections are included in the site
@@ -297,6 +300,15 @@ defaults:
       layout: talk
       author_profile: true
       share: true
+  # _writing
+  - scope:
+      path: ""
+      type: writing
+    values:
+      layout: single
+      author_profile: true
+      share: true
+      comments: true
 
 
 # Sass/SCSS

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -9,7 +9,10 @@ main:
     url: /publications/
 
   - title: "Talks"
-    url: /talks/    
+    url: /talks/
+
+  - title: "Writing"
+    url: /writing/
 
  # - title: "Teaching"
 #  url: /teaching/    

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -42,6 +42,8 @@
           <p> {{ post.type }}, <i>{{ post.venue }}</i>, {{ post.date | default: "1900-01-01" | date: "%Y" }} </p>
         {% elsif post.collection == 'publications' %}
           <p><i>{{ post.venue }}</i>, {{ post.date | date: "%Y" }}</p>
+        {% elsif post.collection == 'working_papers' or post.collection == 'conference' or post.category == 'working_papers' or post.category == 'conferences' %}
+         <p class="page__date"><time datetime="{{ post.date | default: "1900-01-01" | date_to_xmlschema }}">{{ post.date | default: "1900-01-01" | date: "%B %d, %Y" }}</time></p>
         {% elsif post.date %}
          <p class="page__date"><strong><i class="fa fa-fw fa-calendar" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].date_label | default: "Published:" }}</strong> <time datetime="{{ post.date | default: "1900-01-01" | date_to_xmlschema }}">{{ post.date | default: "1900-01-01" | date: "%B %d, %Y" }}</time></p>
         {% endif %}
@@ -61,9 +63,7 @@
     {% elsif post.citation %}
       <p>Recommended citation: 
   {{ post.author | default: "Author" }}. ({{ post.date | date: "%Y" }}). 
-  "{{ post.title }}." <i>{{ post.venue }}</i>
-  {% if post.volume %} {{ post.volume }}{% if post.issue %}({{ post.issue }}){% endif %}{% endif %}
-  {% if post.pages %}, {{ post.pages }}{% endif %}.
+  "{{ post.title }}." <i>{{ post.venue }}</i>{% if post.volume %} {{ post.volume }}{% if post.issue %}({{ post.issue }}){% endif %}{% endif %}{% if post.pages %}, {{ post.pages }}{% endif %}.
   </p>
     {% elsif post.paperurl %}
       <p><a href=" {{ post.paperurl }} ">Download Paper</a></p>

--- a/_pages/writing.html
+++ b/_pages/writing.html
@@ -1,0 +1,10 @@
+---
+layout: archive
+title: "Writing"
+permalink: /writing/
+author_profile: true
+---
+
+{% for post in site.writing reversed %}
+  {% include archive-single-talk.html %}
+{% endfor %}

--- a/_writing/writing-1.md
+++ b/_writing/writing-1.md
@@ -1,0 +1,11 @@
+---
+title: "Rising Sea Levels in Coastal Cities"
+collection: writing
+type: "Article"
+permalink: /writing/rising-sea-levels
+venue: "Coastal Times"
+date: 2022-03-15
+link: https://example.com/rising-sea-levels
+---
+
+A piece discussing how cities adapt to increasing sea levels.

--- a/_writing/writing-2.md
+++ b/_writing/writing-2.md
@@ -1,0 +1,11 @@
+---
+title: "Renewable Energy in Urban Areas"
+collection: writing
+type: "Article"
+permalink: /writing/renewable-energy-urban
+venue: "Green Future"
+date: 2023-07-30
+link: https://example.com/renewable-energy-urban
+---
+
+An article exploring renewable energy options for city life.

--- a/_writing/writing-3.md
+++ b/_writing/writing-3.md
@@ -1,0 +1,11 @@
+---
+title: "Community Farming in the 21st Century"
+collection: writing
+type: "Article"
+permalink: /writing/community-farming
+venue: "Local Harvest"
+date: 2021-11-05
+link: https://example.com/community-farming
+---
+
+Coverage of community-supported agriculture initiatives.


### PR DESCRIPTION
## Summary
- define `writing` collection with defaults
- list entries on new Writing page
- update navigation to include Writing
- add sample writing posts for reference

## Testing
- `npm install`
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_684989a6eb8083259ea65ab3cb99458b