### PR TITLE
Fix talkmap geocoder initialization

### DIFF
--- a/talkmap.ipynb
+++ b/talkmap.ipynb
@@ -55,7 +55,7 @@
    },
    "outputs": [],
    "source": [
-    "geocoder = Nominatim()\n",
+    "geocoder = Nominatim(user_agent=\"academicpages-talkmap\")\n",
     "location_dict = {}\n",
     "location = \"\"\n",
     "permalink = \"\"\n",

--- a/talkmap.py
+++ b/talkmap.py
@@ -18,7 +18,9 @@ from geopy import Nominatim
 g = glob.glob("*.md")
 
 
-geocoder = Nominatim()
+# geopy's Nominatim now requires a user_agent string. Without it, geopy
+# will raise an exception. Provide a basic one so the script runs.
+geocoder = Nominatim(user_agent="academicpages-talkmap")
 location_dict = {}
 location = ""
 permalink = ""


### PR DESCRIPTION
## Summary
- fix `talkmap.py` geocoder initialization by providing a user agent
- update notebook to include same user agent

## Testing
- `python -m py_compile talkmap.py`

------
https://chatgpt.com/codex/tasks/task_e_6849880befc08325aa25a9d622beed79