### PR TITLE
Fix invalid dates causing Jekyll build failure

### DIFF
--- a/_training/training-5.md
+++ b/_training/training-5.md
@@ -4,7 +4,7 @@ layout: single
 type: "Fellowship"
 permalink: /training/training-5/
 venue: "The Mercatus Center at George Mason University"
-date: 2023 - 2024
+date: 2023-06-01
 location: "Fairfax, VA"
 ---
 

--- a/_training/training-9.md
+++ b/_training/training-9.md
@@ -2,9 +2,9 @@
 title: "Ronald Coase Fellowship 2025-2026"
 layout: single
 type: "Fellowship"
-permalink: /training/training-8/
+permalink: /training/training-9/
 venue: "The Mercatus Center at George Mason University"
-date: 2025 - 2026
+date: 2025-06-01
 location: "Fairfax, VA (remote)"
 ---
 


### PR DESCRIPTION
## Summary
- correct invalid dates in training posts
- fix permalink typo in training-9

## Testing
- `bundle exec jekyll build`
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_685afc690e708325a1dc9d5540de5abb