### PR TITLE
Fix invalid dates causing Jekyll build failure

### DIFF
--- a/_training/training-5.md
+++ b/_training/training-5.md
@@ -4,7 +4,7 @@ layout: single
 type: "Fellowship"
 permalink: /training/training-5/
 venue: "The Mercatus Center at George Mason University"
-date: 2023 - 2024
+date: 2023-06-01
 location: "Fairfax, VA"
 ---
 

--- a/_training/training-9.md
+++ b/_training/training-9.md
@@ -2,9 +2,9 @@
 title: "Ronald Coase Fellowship 2025-2026"
 layout: single
 type: "Fellowship"
-permalink: /training/training-8/
+permalink: /training/training-9/
 venue: "The Mercatus Center at George Mason University"
-date: 2025 - 2026
+date: 2025-06-01
 location: "Fairfax, VA (remote)"
 ---
 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ author_profile: true
   <h1>Welcome to James Rice's Academic Portfolio </h1>
   
   <div class="intro">
-    <p>I am a PhD student in the Department of Government at The University of Essex.</p>
+    <p>I am a PhD candidate in the Department of Government at The University of Essex.</p>
     <p>My research interests include quantitative social science, public opinion and misinformation, and environmental governance. My research project, supervised by Dr. Zorzeta Bakaki in the Government Department and funded by the Sustainable Transitions Leverhulme Doctoral Training Scholarship, is on climate change misinformation.</p>
     <p>While my primary discipline is political science, my programme is interdisciplinary in scope, and I have a secondary supervisor, Professor Thankom Arun, in the Essex Business School. </p>
   </div>


### PR DESCRIPTION
## Summary
- correct invalid dates in training posts
- fix permalink typo in training-9
- update homepage text to say PhD candidate

## Testing
- `bundle install`
- `bundle exec jekyll build`
- `npm install`
- `npm run build:js`


------
https://chatgpt.com/codex/tasks/task_e_685afc690e708325a1dc9d5540de5abb