### PR TITLE
Fix navigation wrapping

### DIFF
--- a/_sass/_masthead.scss
+++ b/_sass/_masthead.scss
@@ -52,7 +52,7 @@
   white-space: nowrap;
 
   &--lg {
-    padding-right: 2em;
+    padding-right: 0.5em;
     font-weight: 700;
   }
 }

--- a/_sass/_navigation.scss
+++ b/_sass/_navigation.scss
@@ -62,7 +62,7 @@
     display: flex;
     justify-content: space-evenly;
     align-items: center;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -73,7 +73,7 @@
 
     a {
       display: block;
-      margin: 0 1rem;
+      margin: 0 0.5rem;
       padding: 0.5rem 0;
       color: $masthead-link-color;
       text-decoration: none;


### PR DESCRIPTION
## Summary
- keep nav links on a single line
- shrink padding for site title in the masthead

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_685b0a5d7c388325a507d4535bb230ef